### PR TITLE
Feat: Add Custom Items with Title/Description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "styled-components": "^6.1.8",
         "typeface-arbutus": "^1.1.13",
         "typeface-roboto": "^1.1.13",
-        "typeface-rye": "^1.1.13"
+        "typeface-rye": "^1.1.13",
+        "use-long-press": "^3.2.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -6048,6 +6049,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-long-press": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-3.2.0.tgz",
+      "integrity": "sha512-uq5o2qFR1VRjHn8Of7Fl344/AGvgk7C5Mcb4aSb1ZRVp6PkgdXJJLdRrlSTJQVkkQcDuqFbFc3mDX4COg7mRTA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "styled-components": "^6.1.8",
     "typeface-arbutus": "^1.1.13",
     "typeface-roboto": "^1.1.13",
-    "typeface-rye": "^1.1.13"
+    "typeface-rye": "^1.1.13",
+    "use-long-press": "^3.2.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/src/character/gear/CustomItemService.ts
+++ b/src/character/gear/CustomItemService.ts
@@ -1,0 +1,32 @@
+import { push, ref, remove, set } from "firebase/database";
+import { database } from "../../utils/firebase/Firebase";
+import { CustomItemData } from "../../utils/types/CustomItem";
+
+const API_ROOT = (characterId: string) =>
+  `characters/${characterId}/customItems`;
+
+export const addCustomItem = async (characterId: string) => {
+  const itemToCreate: CustomItemData = {
+    title: "New Item",
+    description: "",
+  };
+  const db = database();
+  const path = API_ROOT(characterId);
+  push(ref(db, path), itemToCreate);
+};
+
+export const deleteCustomitem = async (characterId: string, itemId: string) => {
+  const db = database();
+  const itemPath = `${API_ROOT(characterId)}/${itemId}`;
+  remove(ref(db, itemPath));
+};
+
+export const updateCustomItem = async (
+  characterId: string,
+  itemId: string,
+  itemData: CustomItemData
+) => {
+  const db = database();
+  const itemPath = `${API_ROOT(characterId)}/${itemId}`;
+  set(ref(db, itemPath), itemData);
+};

--- a/src/character/gear/EditCustomItem.tsx
+++ b/src/character/gear/EditCustomItem.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import { TextArea } from "react-aria-components";
+import styled from "styled-components";
+import { Theme } from "../../Theme";
+import { CustomItem, CustomItemData } from "../../utils/types/CustomItem";
+import { updateCustomItem } from "./CustomItemService";
+import { Button } from "../../shared/buttons/Button";
+
+const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 8px;
+  justify-content: space-between;
+`;
+const StyledInput = styled.input`
+  padding: 4px;
+  border-radius: 4px;
+  border: none;
+`;
+const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 8px;
+  justify-content: flex-end;
+`;
+
+type EditCustomItemProps = {
+  characterId: string;
+  item: CustomItem;
+  exitEditMode: () => void;
+};
+const EditCustomItem: React.FC<EditCustomItemProps> = ({
+  characterId,
+  item,
+  exitEditMode,
+}) => {
+  const [editedName, setEditedName] = useState(item.title);
+  const [editedDesc, setEditedDesc] = useState(item.description);
+
+  const commitEdit = (newName: string, newDesc: string) => {
+    exitEditMode();
+    const updatedItem: CustomItemData = {
+      title: newName,
+      description: newDesc,
+    };
+    updateCustomItem(characterId, item.id, updatedItem);
+  };
+  return (
+    <ItemWrapper>
+      <label htmlFor="itemTitle">Title</label>
+      <StyledInput
+        id="itemTitle"
+        name="itemTitle"
+        value={editedName}
+        onChange={(e) => setEditedName(e.target.value)}
+      />
+      <label htmlFor="itemDescription">Description</label>
+      <TextArea
+        id="itemDescription"
+        name="itemDescription"
+        value={editedDesc}
+        onChange={(e) => setEditedDesc(e.target.value)}
+      />
+      <ButtonsWrapper>
+        <Button
+          text="Cancel"
+          customcolor={Theme.Error[100]}
+          onClick={exitEditMode}
+        />
+        <Button
+          text="Save"
+          customcolor={Theme.Stamina}
+          onClick={() => {
+            commitEdit(editedName, editedDesc);
+          }}
+        />
+      </ButtonsWrapper>
+    </ItemWrapper>
+  );
+};
+export default EditCustomItem;

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -1,12 +1,13 @@
-import React, { useContext, useEffect, useState } from "react";
-import styled, { css } from "styled-components";
+import React, { useContext, useState } from "react";
+import styled from "styled-components";
 import { Theme } from "../../Theme";
-import { CustomItem, CustomItemData } from "../../utils/types/CustomItem";
-import { Modal, TextArea } from "react-aria-components";
+import { CustomItem } from "../../utils/types/CustomItem";
+import { Modal } from "react-aria-components";
 import { CharacterContext } from "../../DeadlandsCompanion";
 import { Button } from "../../shared/buttons/Button";
 import { useLongPress } from "use-long-press";
-import { deleteCustomitem, updateCustomItem } from "./CustomItemService";
+import { deleteCustomitem } from "./CustomItemService";
+import EditCustomItem from "./EditCustomItem";
 
 const EditableItemEntryWrapper = styled.div`
   display: flex;
@@ -47,12 +48,6 @@ const ButtonsWrapper = styled.div`
   justify-content: flex-end;
 `;
 
-const StyledInput = styled.input`
-  padding: 4px;
-  border-radius: 4px;
-  border: none;
-`;
-
 type EditableItemEntryProps = {
   item: CustomItem;
 };
@@ -60,22 +55,7 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
   const characterContext = useContext(CharacterContext);
   const [editable, setIsEditable] = useState(false);
   const [expanded, setIsExpanded] = useState(false);
-  const [editedName, setEditedName] = useState(item.title);
-  const [editedDesc, setEditedDesc] = useState(item.description);
   const [showDeletionModal, setShowDeletionModal] = useState(false);
-
-  useEffect(() => {
-    if (item.title !== editedName) setEditedName(item.title);
-  }, [item.title]);
-
-  const commitEdit = (newName: string, newDesc: string) => {
-    setIsEditable(false);
-    const updatedItem: CustomItemData = {
-      title: newName,
-      description: newDesc,
-    };
-    updateCustomItem(characterContext.id, item.id, updatedItem);
-  };
 
   const deleteItem = () => {
     deleteCustomitem(characterContext.id, item.id);
@@ -113,22 +93,11 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
       {deletionConfirmationModal}
       <ItemWrapper>
         {editable ? (
-          <ItemWrapper>
-            <label htmlFor="itemTitle">Title</label>
-            <StyledInput
-              id="itemTitle"
-              name="itemTitle"
-              value={editedName}
-              onChange={(e) => setEditedName(e.target.value)}
-            />
-            <label htmlFor="itemDescription">Description</label>
-            <TextArea
-              id="itemDescription"
-              name="itemDescription"
-              value={editedDesc}
-              onChange={(e) => setEditedDesc(e.target.value)}
-            />
-          </ItemWrapper>
+          <EditCustomItem
+            characterId={characterContext.id}
+            item={item}
+            exitEditMode={() => setIsEditable(false)}
+          />
         ) : (
           <ItemWrapper>
             <ItemTitle>{item.title}</ItemTitle>
@@ -144,24 +113,6 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
           </ItemWrapper>
         )}
       </ItemWrapper>
-      {editable && (
-        <ButtonsWrapper>
-          <Button
-            text="Cancel"
-            customcolor={Theme.Error[100]}
-            onClick={() => {
-              setIsEditable(!editable);
-            }}
-          />
-          <Button
-            text="Save"
-            customcolor={Theme.Stamina}
-            onClick={() => {
-              commitEdit(editedName, editedDesc);
-            }}
-          />
-        </ButtonsWrapper>
-      )}
     </EditableItemEntryWrapper>
   );
 };

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -102,11 +102,7 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
       <ModalContents>
         <div>Delete "{item.title}"?</div>
         <ButtonsWrapper>
-          <Button
-            secondary
-            text="Cancel"
-            onClick={() => setShowDeletionModal(false)}
-          />
+          <Button text="Cancel" onClick={() => setShowDeletionModal(false)} />
           <Button
             customcolor={Theme.Error[100]}
             text="Yes"

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -107,7 +107,11 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
       <ModalContents>
         <div>Delete "{item.title}"?</div>
         <ButtonsWrapper>
-          <Button text="Cancel" onClick={() => setShowDeletionModal(false)} />
+          <Button
+            secondary
+            text="Cancel"
+            onClick={() => setShowDeletionModal(false)}
+          />
           <Button
             customcolor={Theme.Error[100]}
             text="Yes"

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -1,40 +1,179 @@
-import React, { useState } from "react";
-import styled from "styled-components";
-import { Icon } from "../../icons/Icon";
-import { Icons } from "../../icons/Icons";
+import React, { useContext, useEffect, useState } from "react";
+import styled, { css } from "styled-components";
 import { Theme } from "../../Theme";
-type EditableItemEntryStyleProps = {};
-const EditableItemEntryWrapper = styled.div<EditableItemEntryStyleProps>``;
+import { CustomItem, CustomItemData } from "../../utils/types/CustomItem";
+import { Modal, TextArea } from "react-aria-components";
+import { ref, remove, set } from "firebase/database";
+import { database } from "../../utils/firebase/Firebase";
+import { CharacterContext } from "../../DeadlandsCompanion";
+import { Button } from "../../shared/buttons/Button";
+import { useLongPress } from "use-long-press";
+
+const EditableItemEntryWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 4px;
+  ${({}) => css`
+    background-color: ${Theme.Surface[300]};
+  `}
+`;
 type EditableItemEntryProps = {
-  name: string;
-  onNameChange: (name: string) => void;
+  item: CustomItem;
 };
+
+const ModalContents = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ItemTitle = styled.h4`
+  margin: 0;
+  padding: 0;
+  font-size: 1em;
+`;
 
 const ItemWrapper = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   gap: 8px;
-  cursor: pointer;
+  padding: 4px;
+  border-radius: 8px;
+  justify-content: space-between;
 `;
 
-const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ name }) => {
+const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 8px;
+  justify-content: flex-end;
+  button {
+    padding: 4px;
+    border-radius: 4px;
+    border: none;
+  }
+`;
+
+const StyledInput = styled.input`
+  padding: 4px;
+  border-radius: 4px;
+  border: none;
+`;
+
+const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
+  const characterContext = useContext(CharacterContext);
   const [editable, setIsEditable] = useState(false);
-  const [editedName, setEditableName] = useState(name);
+  const [expanded, setIsExpanded] = useState(false);
+  const [editedName, setEditedName] = useState(item.title);
+  const [editedDesc, setEditedDesc] = useState(item.description);
+  const [showDeletionModal, setShowDeletionModal] = useState(false);
+
+  useEffect(() => {
+    if (item.title !== editedName) setEditedName(item.title);
+  }, [item.title]);
+
+  const itemPath = `characters/${characterContext.id}/customItems/${item.id}`;
+
+  const commitEdit = (newName: string, newDesc: string) => {
+    setIsEditable(false);
+    const updatedItem: CustomItemData = {
+      title: newName,
+      description: newDesc,
+    };
+    const db = database();
+    set(ref(db, itemPath), updatedItem);
+  };
+
+  const deleteItem = () => {
+    const db = database();
+    remove(ref(db, itemPath));
+  };
+
+  const longPressHandler = useLongPress(() => {
+    setShowDeletionModal(true);
+  });
+
+  const deletionConfirmationModal = (
+    <Modal
+      isOpen={showDeletionModal}
+      onOpenChange={setShowDeletionModal}
+      isDismissable
+    >
+      <ModalContents>
+        <div>Delete "{item.title}"?</div>
+        <ButtonsWrapper>
+          <Button text="Cancel" onClick={() => setShowDeletionModal(false)} />
+          <Button
+            customcolor={Theme.Error[100]}
+            text="Yes"
+            onClick={deleteItem}
+          />
+        </ButtonsWrapper>
+      </ModalContents>
+    </Modal>
+  );
 
   return (
-    <EditableItemEntryWrapper>
-      {editable ? (
-        <input value={name} onChange={(e) => setEditableName(e.target.value)} />
-      ) : (
-        <ItemWrapper onClick={() => setIsEditable(!editable)}>
-          <div> {name}</div>
-          <Icon
-            icon={Icons.Pen}
-            height={24}
-            width={24}
-            color={Theme.Surface[400]}
+    <EditableItemEntryWrapper
+      {...longPressHandler()}
+      onClick={() => setIsExpanded(!expanded)}
+    >
+      {deletionConfirmationModal}
+      <ItemWrapper>
+        {editable ? (
+          <ItemWrapper>
+            <label htmlFor="itemTitle">Title</label>
+            <StyledInput
+              id="itemTitle"
+              name="itemTitle"
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+            />
+            <label htmlFor="itemDescription">Description</label>
+            <TextArea
+              id="itemDescription"
+              name="itemDescription"
+              value={editedDesc}
+              onChange={(e) => setEditedDesc(e.target.value)}
+            />
+          </ItemWrapper>
+        ) : (
+          <ItemWrapper>
+            <ItemTitle>{item.title}</ItemTitle>
+            {expanded && <div>{item.description}</div>}
+            {expanded && (
+              <Button
+                text="Edit"
+                onClick={() => {
+                  setIsEditable(!editable);
+                }}
+              />
+            )}
+          </ItemWrapper>
+        )}
+      </ItemWrapper>
+      {editable && (
+        <ButtonsWrapper>
+          <Button
+            text="Cancel"
+            customcolor={Theme.Error[100]}
+            onClick={() => {
+              setIsEditable(!editable);
+            }}
           />
-        </ItemWrapper>
+          <Button
+            text="Save"
+            customcolor={Theme.Stamina}
+            onClick={() => {
+              commitEdit(editedName, editedDesc);
+            }}
+          />
+        </ButtonsWrapper>
       )}
     </EditableItemEntryWrapper>
   );

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -3,11 +3,10 @@ import styled, { css } from "styled-components";
 import { Theme } from "../../Theme";
 import { CustomItem, CustomItemData } from "../../utils/types/CustomItem";
 import { Modal, TextArea } from "react-aria-components";
-import { ref, remove, set } from "firebase/database";
-import { database } from "../../utils/firebase/Firebase";
 import { CharacterContext } from "../../DeadlandsCompanion";
 import { Button } from "../../shared/buttons/Button";
 import { useLongPress } from "use-long-press";
+import { deleteCustomitem, updateCustomItem } from "./CustomItemService";
 
 const EditableItemEntryWrapper = styled.div`
   display: flex;
@@ -77,21 +76,17 @@ const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
     if (item.title !== editedName) setEditedName(item.title);
   }, [item.title]);
 
-  const itemPath = `characters/${characterContext.id}/customItems/${item.id}`;
-
   const commitEdit = (newName: string, newDesc: string) => {
     setIsEditable(false);
     const updatedItem: CustomItemData = {
       title: newName,
       description: newDesc,
     };
-    const db = database();
-    set(ref(db, itemPath), updatedItem);
+    updateCustomItem(characterContext.id, item.id, updatedItem);
   };
 
   const deleteItem = () => {
-    const db = database();
-    remove(ref(db, itemPath));
+    deleteCustomitem(characterContext.id, item.id);
   };
 
   const longPressHandler = useLongPress(() => {

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { Icon } from "../../icons/Icon";
+import { Icons } from "../../icons/Icons";
+import { Theme } from "../../Theme";
+type EditableItemEntryStyleProps = {};
+const EditableItemEntryWrapper = styled.div<EditableItemEntryStyleProps>``;
+type EditableItemEntryProps = {
+  name: string;
+  onNameChange: (name: string) => void;
+};
+
+const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  cursor: pointer;
+`;
+
+const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ name }) => {
+  const [editable, setIsEditable] = useState(false);
+  const [editedName, setEditableName] = useState(name);
+
+  return (
+    <EditableItemEntryWrapper>
+      {editable ? (
+        <input value={name} onChange={(e) => setEditableName(e.target.value)} />
+      ) : (
+        <ItemWrapper onClick={() => setIsEditable(!editable)}>
+          <div> {name}</div>
+          <Icon
+            icon={Icons.Pen}
+            height={24}
+            width={24}
+            color={Theme.Surface[400]}
+          />
+        </ItemWrapper>
+      )}
+    </EditableItemEntryWrapper>
+  );
+};
+export default EditableItemEntry;

--- a/src/character/gear/EditableItemEntry.tsx
+++ b/src/character/gear/EditableItemEntry.tsx
@@ -13,14 +13,8 @@ const EditableItemEntryWrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   border-radius: 4px;
-  ${({}) => css`
-    background-color: ${Theme.Surface[300]};
-  `}
+  background-color: ${Theme.Surface[300]};
 `;
-type EditableItemEntryProps = {
-  item: CustomItem;
-};
-
 const ModalContents = styled.div`
   display: flex;
   flex-direction: column;
@@ -51,11 +45,6 @@ const ButtonsWrapper = styled.div`
   padding: 4px;
   border-radius: 8px;
   justify-content: flex-end;
-  button {
-    padding: 4px;
-    border-radius: 4px;
-    border: none;
-  }
 `;
 
 const StyledInput = styled.input`
@@ -64,6 +53,9 @@ const StyledInput = styled.input`
   border: none;
 `;
 
+type EditableItemEntryProps = {
+  item: CustomItem;
+};
 const EditableItemEntry: React.FC<EditableItemEntryProps> = ({ item }) => {
   const characterContext = useContext(CharacterContext);
   const [editable, setIsEditable] = useState(false);

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -51,7 +51,7 @@ export const Gear = () => {
       Coming soon...
       <TitleRow>
         <h4>Custom Items</h4>
-        <IconButton icon={Icons.Add} onClick={addItem} />
+        <IconButton transparent icon={Icons.Add} onClick={addItem} />
       </TitleRow>
       <GearListWrapper>
         {items.map((item) => (

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -1,8 +1,16 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import Page from "../../shared/page/Page";
 import { Locations } from "../../utils/Location";
 import { Money } from "./Money";
 import EditableItemEntry from "./EditableItemEntry";
+import { useContext } from "react";
+import { CharacterContext } from "../../DeadlandsCompanion";
+import { Icon } from "../../icons/Icon";
+import { Icons } from "../../icons/Icons";
+import { Theme } from "../../Theme";
+import { CustomItemData } from "../../utils/types/CustomItem";
+import { push, ref } from "firebase/database";
+import { database } from "../../utils/firebase/Firebase";
 
 const GearListWrapper = styled.div`
   display: flex;
@@ -10,27 +18,59 @@ const GearListWrapper = styled.div`
   gap: 8px;
 `;
 
-export const Gear = () => {
-  const items = [
-    "Ammo",
-    "Weapons",
-    "Armor",
-    "Clothing",
-    "Tools",
-    "Consumables",
-    "Miscellaneous",
-  ];
+const TitleRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 4px;
+  button {
+    padding: 4px;
+    border-radius: 4px;
+    border: none;
+    background-color: transparent;
+  }
+`;
 
-  const onUpdateItem = (name: string) => {};
+export const Gear = () => {
+  const characterContext = useContext(CharacterContext);
+
+  const mapToItemList = () => {
+    if (characterContext.customItems) {
+      return Object.entries(characterContext.customItems).map(([id, item]) => {
+        return { ...item, id };
+      });
+    }
+    return [];
+  };
+
+  const items = mapToItemList();
+
+  const addItem = () => {
+    const itemToCreate: CustomItemData = {
+      title: "New Item",
+      description: "",
+    };
+    const db = database();
+    push(
+      ref(db, `characters/${characterContext?.id}/customItems`),
+      itemToCreate
+    );
+  };
 
   return (
     <Page pageName="Gear" prevLocation={Locations.CharacterMenu}>
       <Money />
-      Coming soon...
-      <h4>Gear List</h4>
+      <TitleRow>
+        <h4>Gear List</h4>
+        <button onClick={addItem}>
+          <Icon icon={Icons.Add} height={24} width={24} />
+        </button>
+      </TitleRow>
       <GearListWrapper>
         {items.map((item) => (
-          <EditableItemEntry name={item} onNameChange={onUpdateItem} />
+          <EditableItemEntry key={item.id} item={item} />
         ))}
       </GearListWrapper>
     </Page>

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -11,6 +11,7 @@ import { Theme } from "../../Theme";
 import { CustomItemData } from "../../utils/types/CustomItem";
 import { push, ref } from "firebase/database";
 import { database } from "../../utils/firebase/Firebase";
+import { addCustomItem } from "./CustomItemService";
 
 const GearListWrapper = styled.div`
   display: flex;
@@ -48,15 +49,7 @@ export const Gear = () => {
   const items = mapToItemList();
 
   const addItem = () => {
-    const itemToCreate: CustomItemData = {
-      title: "New Item",
-      description: "",
-    };
-    const db = database();
-    push(
-      ref(db, `characters/${characterContext?.id}/customItems`),
-      itemToCreate
-    );
+    addCustomItem(characterContext.id);
   };
 
   return (

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -1,17 +1,13 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import Page from "../../shared/page/Page";
 import { Locations } from "../../utils/Location";
 import { Money } from "./Money";
 import EditableItemEntry from "./EditableItemEntry";
 import { useContext } from "react";
 import { CharacterContext } from "../../DeadlandsCompanion";
-import { Icon } from "../../icons/Icon";
 import { Icons } from "../../icons/Icons";
-import { Theme } from "../../Theme";
-import { CustomItemData } from "../../utils/types/CustomItem";
-import { push, ref } from "firebase/database";
-import { database } from "../../utils/firebase/Firebase";
 import { addCustomItem } from "./CustomItemService";
+import { IconButton } from "../../shared/buttons/IconButton";
 
 const GearListWrapper = styled.div`
   display: flex;
@@ -26,12 +22,6 @@ const TitleRow = styled.div`
   align-items: center;
   justify-content: space-between;
   border-radius: 4px;
-  button {
-    padding: 4px;
-    border-radius: 4px;
-    border: none;
-    background-color: transparent;
-  }
 `;
 
 export const Gear = () => {
@@ -61,9 +51,7 @@ export const Gear = () => {
       Coming soon...
       <TitleRow>
         <h4>Custom Items</h4>
-        <button onClick={addItem}>
-          <Icon icon={Icons.Add} height={24} width={24} />
-        </button>
+        <IconButton icon={Icons.Add} onClick={addItem} />
       </TitleRow>
       <GearListWrapper>
         {items.map((item) => (

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -1,12 +1,38 @@
+import styled from "styled-components";
 import Page from "../../shared/page/Page";
 import { Locations } from "../../utils/Location";
 import { Money } from "./Money";
+import EditableItemEntry from "./EditableItemEntry";
+
+const GearListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
 
 export const Gear = () => {
+  const items = [
+    "Ammo",
+    "Weapons",
+    "Armor",
+    "Clothing",
+    "Tools",
+    "Consumables",
+    "Miscellaneous",
+  ];
+
+  const onUpdateItem = (name: string) => {};
+
   return (
     <Page pageName="Gear" prevLocation={Locations.CharacterMenu}>
       <Money />
       Coming soon...
+      <h4>Gear List</h4>
+      <GearListWrapper>
+        {items.map((item) => (
+          <EditableItemEntry name={item} onNameChange={onUpdateItem} />
+        ))}
+      </GearListWrapper>
     </Page>
   );
 };

--- a/src/character/gear/Gear.tsx
+++ b/src/character/gear/Gear.tsx
@@ -63,7 +63,11 @@ export const Gear = () => {
     <Page pageName="Gear" prevLocation={Locations.CharacterMenu}>
       <Money />
       <TitleRow>
-        <h4>Gear List</h4>
+        <h4>Gear</h4>
+      </TitleRow>
+      Coming soon...
+      <TitleRow>
+        <h4>Custom Items</h4>
         <button onClick={addItem}>
           <Icon icon={Icons.Add} height={24} width={24} />
         </button>

--- a/src/codex/Hindrances/HindrancePage.tsx
+++ b/src/codex/Hindrances/HindrancePage.tsx
@@ -1,4 +1,3 @@
-import { styled } from "styled-components";
 import Page from "../../shared/page/Page";
 import { Locations } from "../../utils/Location";
 import { HindranceList } from "../../static/hindrances/HindranceList";
@@ -7,6 +6,7 @@ import { Search } from "../../shared/Search";
 import { useState } from "react";
 import { HindranceDetailType } from "../../utils/interfaces/HindranceDetail";
 import { Header } from "../shared/Header";
+import styled from "styled-components";
 
 const HindranceGroupsWrapper = styled.div`
   display: flex;

--- a/src/utils/types/Character.ts
+++ b/src/utils/types/Character.ts
@@ -1,5 +1,6 @@
 import { Attribute, DieType, Edge, Rank, Skill } from "../enums";
 import { Weapon } from "../enums/Weapon";
+import { CustomItem } from "./CustomItem";
 import { Effect } from "./Effect";
 
 type WeaponRecord = {
@@ -27,5 +28,6 @@ export type Character = {
   weapons?: Record<Weapon, WeaponRecord>;
   powers?: Record<string, number>; // Stores current powerpoints as value, but only used for weird scientists.
   gear?: Record<string, true>;
+  customItems?: Record<string, CustomItem>;
   effects?: Effect[];
 };

--- a/src/utils/types/CustomItem.ts
+++ b/src/utils/types/CustomItem.ts
@@ -1,0 +1,7 @@
+export type CustomItem = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+export type CustomItemData = Omit<CustomItem, "id">;


### PR DESCRIPTION
Adds a "Custom Items" feature, which allows users to add, update and delete Custom Items with a title and/or description under their gear list.

Items can be added using the Plus button. They can be expanded via click, where title/description can be edited. I felt cute, so deletion happens through the long press gesture using `use-long-press`.

![image](https://github.com/LukasTvegaard/deadlands-companion/assets/23666856/59ce036c-0e33-4b1b-bea9-c924a6fd107d)
